### PR TITLE
Redirect logged-in users from home page to dashboard

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,15 @@
 import Image from "next/image";
+import { auth } from "@clerk/nextjs/server";
+import { redirect } from "next/navigation";
 
-export default function Home() {
+export default async function Home() {
+  const { userId } = await auth();
+
+  // Redirect logged-in users to dashboard
+  if (userId) {
+    redirect("/dashboard");
+  }
+
   return (
     <div className="flex min-h-screen items-center justify-center bg-zinc-50 font-sans dark:bg-black">
       <main className="flex min-h-screen w-full max-w-3xl flex-col items-center justify-between py-32 px-16 bg-white dark:bg-black sm:items-start">


### PR DESCRIPTION
- Added auth check using Clerk's auth() function in app/page.tsx
- Implemented server-side redirect to /dashboard for authenticated users
- Made Home component async to support server-side authentication

This ensures logged-in users are automatically redirected to their dashboard when they try to access the home page.

Fixes #3

🤖 Generated with [Claude Code](https://claude.ai/code)